### PR TITLE
Feature/admin

### DIFF
--- a/src/MinecrunchWeb/settings.py
+++ b/src/MinecrunchWeb/settings.py
@@ -31,7 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin.apps.SimpleConfig',
+    'django.contrib.admin.apps.SimpleAdminConfig',
     'adminplus',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/src/MinecrunchWeb/settings.py
+++ b/src/MinecrunchWeb/settings.py
@@ -31,7 +31,8 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
+    'django.contrib.admin.apps.SimpleConfig',
+    'adminplus',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -121,4 +122,4 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"),]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"), ]

--- a/src/MinecrunchWeb/settings.py
+++ b/src/MinecrunchWeb/settings.py
@@ -31,8 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin.apps.SimpleAdminConfig',
-    'adminplus',
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -40,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'home',
     'modpacks',
+    'whitelist',
 ]
 
 MIDDLEWARE = [
@@ -122,4 +122,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"), ]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"),]
+
+# Location of the server whitelist file
+WHITELIST_FILE = '/tmp/whitelist.json'

--- a/src/MinecrunchWeb/urls.py
+++ b/src/MinecrunchWeb/urls.py
@@ -15,6 +15,10 @@ Including another URLconf
 """
 from django.conf.urls import url, include
 from django.contrib import admin
+from adminplus.sites import AdminSitePlus
+
+admin.site = AdminSitePlus()
+admin.autodiscover()
 
 urlpatterns = [
     url(r'^home/', include('home.urls')),

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 MinecrunchWeb
+Django
 django-adminplus>=0.5

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,2 @@
+MinecrunchWeb
+django-adminplus>=0.5


### PR DESCRIPTION
Add the "AdminSitePlus" package to allow adding custom views to the admin section. This extends the existing Django admin, so that there is no modification required to our current code. We just get the ability to add custom views.

Short, sweet, and probably what I would have tried to make myself!
